### PR TITLE
fix failing jruby builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ rvm:
   - ruby-head
   - 2.2.3
   - 2.1.5 # developing here, for now
+  - jruby-head
   - jruby-9.0.0.0
-  - jruby-1.7.20
+  - jruby-19mode # jruby-1.7.x in 1.9 mode
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.0.0.0 # pry-byebug (interactive debugging gem) doesn't load for jruby
-    - rvm: jruby-1.7.20  # pry-byebug doesn't load for jruby
+    - rvm: jruby-head
   fast_finish: true
 env:
   global:

--- a/spec/f880_macros_spec.rb
+++ b/spec/f880_macros_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 RSpec.describe 'f880_macros' do
 
   let!(:indexer) do


### PR DESCRIPTION
by specifying utf8 encoding in f880_macros_spec

@jgreben 
